### PR TITLE
Create input_datetime for gas tank estimation

### DIFF
--- a/packages/gas_tracking/furnace_usage_since_last_check.yaml
+++ b/packages/gas_tracking/furnace_usage_since_last_check.yaml
@@ -8,6 +8,6 @@ entity_id: binary_sensor.furnace_is_heating
 state: "on"
 type: time
 start: |
-  {{ states.input_number.last_measured_gas_tank_level.last_updated }}
+  {{ states('input_datetime.gas_tank_last_checked') }}
 end: |
   {{ now() }}

--- a/packages/gas_tracking/input_datetime.yaml
+++ b/packages/gas_tracking/input_datetime.yaml
@@ -1,0 +1,4 @@
+gas_tank_last_checked:
+  name: Gas tank last checked
+  has_date: true
+  has_time: true

--- a/packages/gas_tracking/notifications.yaml
+++ b/packages/gas_tracking/notifications.yaml
@@ -6,6 +6,25 @@
 # - https://companion.home-assistant.io/docs/notifications/actionable-notifications/
 
 
+- id: on_tank_checked
+  alias: "Gas tank: On new value"
+  description: Remember when the gas tank was last checked
+  trigger: 
+    - platform: event
+      event_type: call_service
+      event_data:
+        domain: input_number
+        service: set_value
+        service_data:
+          entity_id: input_number.tank_usage_factor
+
+  action:
+    - service: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.gas_tank_last_checked
+      datetime: |
+        {{ now() }}
+
 - id: on_tank_check_recommended
   alias: "Gas tank: On check recommended"
   description: Notifies household members when a gas tank check is needed


### PR DESCRIPTION
# What did I change? 

Fixed an issue with the recent gas tank estimations in #4. 

Home Assistant does not store when the input_number was changed along restarts, so whenever Home Assistant restarts (any code change, software update, etc), the gas tank would go back to the last estimated value.

This creates a datetime that automatically updates to the current timestamp when a new value is entered for an actual measurement. It also allows for things like, "I checked the tank yesterday and it as at X%, but forgot to put it in Home Assistant."

# How was it tested?

Not tested.